### PR TITLE
Add support for changing the system hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Usage:
   pifi add <ssid> <password>  Adds a connection to scan/connect to on bootup (needs sudo)
   pifi list seen              Lists the SSIDs that see seen during bootup
   pifi list pending           Lists the SSIDs that still need to configured in NetworkManager
-  pifi set-hostname <hostname> Set the hostname of the system, also changes the default AP mode ssid
+  pifi set-hostname <hostname> Set the hostname of the system, also deletes existing AP mode configurations
   pifi --version              Prints the version of pifi on your system
 
 Options:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Usage:
   pifi add <ssid> <password>  Adds a connection to scan/connect to on bootup (needs sudo)
   pifi list seen              Lists the SSIDs that see seen during bootup
   pifi list pending           Lists the SSIDs that still need to configured in NetworkManager
+  pifi set-hostname <hostname> Set the hostname of the system, also changes the default AP mode ssid
   pifi --version              Prints the version of pifi on your system
 
 Options:
@@ -26,10 +27,10 @@ Pifi runs a script at boot up that does the following by default:
 * Go through any pending connections in `/var/lib/pifi/pending`, and see if any are visiable
 * If any of the pending connections are visible, connect to them, and remove them from pending
 * Otherwise look for an existing AP mode definiton and start it
-* If there is no existing AP mode definition create one with the configuration in `/etc/pifi/default_ap.em` (SSID:'UbiquityRobot<4HEX>' and password:'robotseverywhere'). (Where <4HEX> is the last 4 digits of the device mac address.)
+* If there is no existing AP mode definition create one with the configuration in `/etc/pifi/default_ap.em` (SSID:'<HOSTNAME><4HEX>' and password:'robotseverywhere'). (Where <HOSTNAME> is the hostname of the system and <4HEX> is the last 4 digits of the device mac address.)
 
 ## Connecting to a network while in AP mode
-Connect to the ap mode wifi (default UbiquityRobot<4HEX>, password robotseverywhere) on your laptop. (Where <4HEX> is the last 4 digits of the device mac address.)
+Connect to the ap mode wifi (default <HOSTNAME><4HEX>', password robotseverywhere) on your laptop. (Where <HOSTNAME> is the hostname of the system and <4HEX> is the last 4 digits of the device mac address.)
 
 SSH into the device with `ssh ubuntu@10.42.0.1`. 
 
@@ -81,7 +82,7 @@ client_device: any
 
 The settings of the default AP that pifi creates are also configurable. `/etc/pifi/default_ap.em` contains and empy template of the json that represents the connection settings.
 
-The varibles passed into the template are the MAC address of the device (mac), and a newly generated UUIDv4 (uuid_str).
+The varibles passed into the template are the hostname of the system (hostname), the MAC address of the device (mac), and a newly generated UUIDv4 (uuid_str).
 
 This is the default configuration:
 ```
@@ -96,7 +97,7 @@ This is the default configuration:
     "802-11-wireless": {
         "mode": "ap",
         "security": "802-11-wireless-security",
-        "ssid": "UbiquityRobot@(mac.replace(":", "")[-4:])"
+        "ssid": "@(hostname)@(mac.replace(":", "")[-4:])"
     },
 
     "802-11-wireless-security": {
@@ -111,6 +112,7 @@ This is the default configuration:
         "method": "ignore"
     }
 }
+
 ```
 
 Empy uses the template format `@()` with python expressions inside of the parenthesis.

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ The default configuration file is:
 # YAML configuration file for pifi
 
 # Should pifi delete other ap mode configurations in NetworkManager?
-# Default: False
+# Default: True
 # If true, during the next boot where there are no networks availble 
 # pifi will delete existing connections, and create a new default one
-delete_existing_ap_connections: False
+delete_existing_ap_connections: True
 
 # The network interface to use for AP mode
 # Default: any

--- a/default_ap.em
+++ b/default_ap.em
@@ -9,7 +9,7 @@
     "802-11-wireless": {
         "mode": "ap",
         "security": "802-11-wireless-security",
-        "ssid": "UbiquityRobot@(mac.replace(":", "")[-4:])"
+        "ssid": "@(hostname)@(mac.replace(":", "")[-4:])"
     },
 
     "802-11-wireless-security": {

--- a/pifi.conf
+++ b/pifi.conf
@@ -1,10 +1,10 @@
 # YAML configuration file for pifi
 
 # Should pifi delete other ap mode configurations in NetworkManager?
-# Default: False
+# Default: True
 # If true, during the next boot where there are no networks availble 
 # pifi will delete existing connections, and create a new default one
-delete_existing_ap_connections: False
+delete_existing_ap_connections: True
 
 # The network interface to use for AP mode
 # Default: any

--- a/pifi/etc_io.py
+++ b/pifi/etc_io.py
@@ -24,7 +24,11 @@ if sys.version_info[0] >= 3.5:
     JSONDecodeError = json.decoder.JSONDecodeError
 
 def get_default_ap_conf(mac, open=open):
-    hostname = get_hostname(open=open)
+    hostname = "pifi" # Default value
+    try:
+        hostname = get_hostname(open=open)
+    except Exception as e:
+        pass
     fallback_ap_conf = \
     {
         'connection': {

--- a/pifi/etc_io.py
+++ b/pifi/etc_io.py
@@ -74,7 +74,7 @@ def get_default_ap_conf(mac, open=open):
 
 default_conf = \
 {
-    'delete_existing_ap_connections' : False,
+    'delete_existing_ap_connections' : True,
     'ap_device' : 'any',
     'client_device' : 'any'
 }

--- a/pifi/etc_io.py
+++ b/pifi/etc_io.py
@@ -7,19 +7,24 @@ For now this is just the default AP configuration
 default_ap_path = "/etc/pifi/default_ap.em"
 conf_path = "/etc/pifi/pifi.conf"
 
-# default_ap_path = "../default_ap.em"
-# conf_path = "../pifi.conf"
+hostname_path = "/etc/hostname"
+hosts_path = "/etc/hosts"
+
+default_ap_path = "../default_ap.em"
+conf_path = "../pifi.conf"
 
 import os, sys
 import em
 import json, yaml
 import uuid
+import re
 
 JSONDecodeError = ValueError
 if sys.version_info[0] >= 3.5:
     JSONDecodeError = json.decoder.JSONDecodeError
 
 def get_default_ap_conf(mac, open=open):
+    hostname = get_hostname(open=open)
     fallback_ap_conf = \
     {
         'connection': {
@@ -32,7 +37,7 @@ def get_default_ap_conf(mac, open=open):
         '802-11-wireless': {
             'mode': 'ap',
             'security': '802-11-wireless-security',
-            'ssid': 'UbiquityRobot%4s' % mac.replace(":", "")[-4:]
+            'ssid': '%s%4s' % (hostname, mac.replace(":", "")[-4:])
         },
 
         '802-11-wireless-security': {
@@ -47,7 +52,12 @@ def get_default_ap_conf(mac, open=open):
     try:
         with open(default_ap_path) as ap_conf_file:
             ap_conf = ap_conf_file.read()
-            expanded_ap_conf = em.expand(ap_conf, {"mac": mac, "uuid_str": str(uuid.uuid4())})
+            expanded_ap_conf = em.expand(ap_conf, {
+                "mac": mac, 
+                "uuid_str": str(uuid.uuid4()), 
+                "hostname": hostname
+                }
+            )
             return json.loads(expanded_ap_conf)
     except FileNotFoundError:
         print("WARN /etc/pifi/default_ap.em doesn't exist, using fallback configuration")
@@ -84,3 +94,27 @@ def get_conf(open=open):
     except yaml.parser.ParserError:
         print("WARN failed to parse /etc/pifi/pifi.conf, using default configuration")
         return default_conf
+
+def get_hostname(open=open):
+    with open(hostname_path) as hostname_file:
+        return hostname_file.read().strip()
+
+
+def change_hostline(old_hostname, new_hostname, line):
+    if line.startswith("127.") and 'localhost' not in line:
+        return line.replace(old_hostname, new_hostname)
+    else:
+        return line
+
+def set_hostname(old_hostname, new_hostname, open=open):
+    with open(hostname_path, 'w+') as hostname_file:
+        hostname_file.truncate()
+        hostname_file.write('%s\n' % new_hostname)
+
+    hosts_lines = []
+    with open(hosts_path, 'r+') as hosts_file:
+        hosts_lines = hosts_file.readlines()
+        hosts_lines = [change_hostline(old_hostname, new_hostname, line) for line in hosts_lines]
+
+    with open(hosts_path, 'w') as hosts_file:
+        hosts_file.writelines(hosts_lines)

--- a/pifi/pifi.py
+++ b/pifi/pifi.py
@@ -119,12 +119,6 @@ def set_hostname(new_hostname):
 
     try:
         etc_io.set_hostname(old_hostname, new_hostname)
-
-        print("Deleting existing AP mode configurations")
-        for connection in nm.existingAPConnections():
-            print("Deleting existing AP mode connection, SSID: %s" % 
-                connection.GetSettings()['802-11-wireless']['ssid'])
-            connection.Delete()
     except PermissionError:
         print("Error writing to /etc/hosts or /etc/hostname, make sure you are running with sudo")
 

--- a/pifi/pifi.py
+++ b/pifi/pifi.py
@@ -119,6 +119,12 @@ def set_hostname(new_hostname):
 
     try:
         etc_io.set_hostname(old_hostname, new_hostname)
+
+        print("Deleting existing AP mode configurations")
+        for connection in nm.existingAPConnections():
+            print("Deleting existing AP mode connection, SSID: %s" % 
+                connection.GetSettings()['802-11-wireless']['ssid'])
+            connection.Delete()
     except PermissionError:
         print("Error writing to /etc/hosts or /etc/hostname, make sure you are running with sudo")
 

--- a/pifi/pifi.py
+++ b/pifi/pifi.py
@@ -6,6 +6,7 @@ Usage:
   pifi add <ssid> [<password>]
   pifi list seen
   pifi list pending
+  pifi set-hostname <hostname>
   pifi --version
 
 Options:
@@ -21,6 +22,7 @@ import os
 
 import pifi.nm_helper as nm
 import pifi.var_io as var_io
+import pifi.etc_io as etc_io
 
 import uuid
 
@@ -110,6 +112,16 @@ def list_pending():
             print("WARN: Found non wireless pending connection: %s" % 
                     con['connection']['id'])
 
+
+def set_hostname(new_hostname):
+    old_hostname = etc_io.get_hostname()
+    print("Changing hostname from %s to %s" % (old_hostname, new_hostname))
+
+    try:
+        etc_io.set_hostname(old_hostname, new_hostname)
+    except PermissionError:
+        print("Error writing to /etc/hosts or /etc/hostname, make sure you are running with sudo")
+
 def main():
     arguments = docopt(__doc__, version='pifi version 0.3.0')
     
@@ -124,3 +136,5 @@ def main():
         list_seen()
     if arguments['list'] and arguments['pending']:
         list_pending()
+    if arguments['set-hostname']:
+        set_hostname(arguments['<hostname>'])


### PR DESCRIPTION
Also make re-doing the AP mode configuration the default, so that if the hostname is changed the SSID will also change. 

Fixes #3 