### PR TITLE
AP channel fix

### DIFF
--- a/pifi/etc_io.py
+++ b/pifi/etc_io.py
@@ -17,6 +17,7 @@ import em
 import json, yaml
 import uuid
 import re
+import ctypes
 
 JSONDecodeError = ValueError
 if sys.version_info[0] >= 3.5:
@@ -75,6 +76,14 @@ def get_default_ap_conf(mac, open=open):
                         ap_config["connection"]["autoconnect"] = True
                     else:
                         ap_config["connection"]["autoconnect"] = False
+                        
+            if "802-11-wireless" in ap_config: 
+                if "channel" in ap_config["802-11-wireless"]:   
+                    tmp = int(ap_config["802-11-wireless"]["channel"])
+                    del ap_config["802-11-wireless"]["channel"]
+                    # The networkmanager demands the value as uint32, hopefully this'll do
+                    ap_config["802-11-wireless"]["channel"] = ctypes.c_uint32(tmp).value
+                        
             return ap_config
     except FileNotFoundError:
         print(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pifi",
-    version="0.9.0",
+    version="0.9.1",
     description="Wifi provisioning tools for robots with Raspberry Pis",
     url="https://github.com/rohbotics/pifi",
     author="Rohan Agrawal",


### PR DESCRIPTION
So turns out what seems to be the issue with picking an AP mode channel is the same as the autoconnect issue, in that the NM expects a boolean or in this case a uint32, when it gets a string and throws a tantrum.

Confirmed working using the manual install option mentioned in the ReadMe.

Anyhow I would suggest looking up all the other params that can exist that aren't strings, and adding the manual type correction for all so we can finally call it good.